### PR TITLE
feat: no commit suffix for git tag image refs

### DIFF
--- a/github-cache-bake.hcl
+++ b/github-cache-bake.hcl
@@ -9,6 +9,10 @@ variable "HOST" {
 variable "GITHUB_REF_PROTECTED" {
   default = "false"
 }
+variable "GITHUB_REF_TYPE" {
+  // Assume CI contexts are for branches
+  default = "branch"
+}
 variable "GITHUB_SHA" {
   // If not running in CI, assume local
   default = "local"
@@ -49,7 +53,7 @@ target "default" {
     "type=docker,name=${IMAGE_NAME}",
     // If running for an unprotected ref (e.g. PRs), append the commit SHA
     (
-      "${GITHUB_REF_PROTECTED}" == "true"
+      ("${GITHUB_REF_PROTECTED}" == "true" || "${GITHUB_REF_TYPE}" == "tag" )
       ? "type=registry,name=${IMAGE_REF}:${VERSION}"
       : "type=registry,name=${IMAGE_REF}:${VERSION}-${GITHUB_SHA}"
     )


### PR DESCRIPTION
Closes #19 

> ## What
> 
> Skip commit image tag suffix in contexts of CI workflows for git tags
> 
> ## Why
> 
> Git tags often represent releases, and regardless are always immutable. Therefore, image tags for them without commit suffixes are often desirable, and always sufficient for unambiguous understanding of version.
> 
> ## How
> 
> Read the `GITHUB_REF_TYPE` variable to determine if the context is a CI workflow for a tag. The provided `GITHUB_REF_PROTECTED` variable is [never `true` for tags, even if protected](https://github.com/orgs/community/discussions/142985), so useless for this case.
> 