### PR TITLE
Avoid timestamp cache invalidations

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -53,7 +53,7 @@ rulesets:
       - type: required_status_checks
         parameters:
           required_status_checks:
-            - context: release-it workflow / Release-it dry-run
+            - context: release-it-workflow / Release-it dry-run
               integration_id: 15368 # GitHub Actions integration ID
           # Requires PR branches to be up-to-date with target
           strict_required_status_checks_policy: true

--- a/docker-client/Dockerfile
+++ b/docker-client/Dockerfile
@@ -3,5 +3,7 @@ FROM base_context
 
 USER root
 COPY --from=docker_image /usr/local/bin/docker /usr/local/bin/docker
+COPY --from=docker_image /usr/local/libexec/docker/cli-plugins/docker-buildx /usr/local/libexec/docker/cli-plugins/docker-buildx
+COPY --from=docker_image /usr/local/libexec/docker/cli-plugins/docker-compose /usr/local/libexec/docker/cli-plugins/docker-compose
 ARG DOCKER_GID=800
 RUN groupadd --gid $DOCKER_GID docker

--- a/github-cache-bake.hcl
+++ b/github-cache-bake.hcl
@@ -47,7 +47,7 @@ target "default" {
     "type=registry,ref=${IMAGE_REF}-cache:${VERSION}"
   ]
   cache-to = [
-    "type=registry,ref=${IMAGE_REF}-cache:${VERSION}"
+    "type=registry,rewrite-timestamp=true,mode=max,ref=${IMAGE_REF}-cache:${VERSION}"
   ]
   output = [
     "type=docker,name=${IMAGE_NAME}",


### PR DESCRIPTION
Closes #23

> ## What
> 
> Avoid cache invalidations for the GitHub cache build Bake file due to varying timestamps from build environments
> 
> ## Why
> 
> Build contexts across which cache matches are desired often contain varying timestamps. See https://github.com/moby/buildkit/blob/master/docs/build-repro.md
> 
> ## How
> 
> Leverage the `rewrite-timestamp=true,` and the `mode=max` output options in cache-to configuration