### PR TITLE
Fix pre-commit common context resolve failure

### DIFF
--- a/pre-commit/caller.Dockerfile
+++ b/pre-commit/caller.Dockerfile
@@ -1,7 +1,4 @@
 # hadolint ignore=DL3006
-FROM common_context AS common_context
-
-# hadolint ignore=DL3006
 FROM base_context
 ARG USER=root
 
@@ -35,5 +32,5 @@ ENV DEVCONTAINER_PRE_COMMIT_IMAGE=$DEVCONTAINER_PRE_COMMIT_IMAGE
 COPY pre-commit/pre-commit /usr/local/bin
 
 # Include pre-commit initialization in config for devcontainers onCreateCommand, postCreateCommand
-COPY --from=common_context on_create_command /opt/devcontainers/on_create_command
+COPY common/on_create_command /opt/devcontainers/on_create_command
 COPY pre-commit/on_create_command /opt/devcontainers/on_create_command

--- a/pre-commit/devcontainer-bake.hcl
+++ b/pre-commit/devcontainer-bake.hcl
@@ -30,9 +30,8 @@ target "pre-commit-tool-image" {
 target "pre-commit" {
   dockerfile = "pre-commit/caller.Dockerfile"
   contexts = {
-    local_context  = BAKE_CMD_CONTEXT
-    common_context = "common"
-    base_context   = "target:pre-commit-base"
+    local_context = BAKE_CMD_CONTEXT
+    base_context  = "target:pre-commit-base"
     // Tool context is unused; referenced only to establish it as a dep
     tool_context = "target:pre-commit-tool-image"
   }


### PR DESCRIPTION
Closes #31 

> ## What
> 
> Fix failure to resolve the pre-commit common context in remote executions
> 
> ## Why
> 
> The primary use of the pre-commit bake file is as a [bake remote definition](https://docs.docker.com/build/bake/remote-definition/). The common context must resolve in these cases.
> 
> Currently, use of the pre-commit remote bake definition results in the following error:
> 
> ```bash
> 2025-02-15 17:21:41.789Z: Status: Downloaded newer image for ghcr.io/********:0.6.02025-02-15 17:21:41.790Z: 
> 2025-02-15 17:21:59.622Z: #0 building with "initialize-builder" instance using docker-container driver
> 
> #1 [internal] load git source ********/********/dockerfile-partials.git#0.4.1
> 2025-02-15 17:21:59.788Z: #1 0.319 8aa46fa6e2dc6738ecfe90ef84bf13f9bdc7d05d2025-02-15 17:21:59.788Z: 	refs/tags/0.4.1
> 2025-02-15 17:22:00.011Z: #1 ...
> 
> #2 [internal] load local bake definitions2025-02-15 17:22:00.011Z: 
> #2 reading .devcontainer/devcontainer-bake.hcl 255B / 255B done
> #2 DONE 0.0s
> 
> #1 [docker-client internal] load git source ********/********/dockerfile-partials.git#0.4.1
> #1 0.324 91d0a55cbe36ae1e0f4d8595d656e7eb1ee4d6d9	refs/tags/0.4.1^{}
> 2025-02-15 17:22:00.116Z: #1 0.254 8aa46fa6e2dc6738ecfe90ef84bf13f9bdc7d05d	refs/tags/0.4.1
> 2025-02-15 17:22:00.273Z: #1 0.258 91d0a55cbe36ae1e0f4d8595d656e7eb1ee4d6d9	refs/tags/0.4.1^{}
> #1 CACHED
> 
> ...
> 
> --------------------
>   36 |     
>   37 |     # Include pre-commit initialization in config for devcontainers onCreateCommand, postCreateCommand
>   38 | >>> COPY --from=common_context on_create_command /opt/devcontainers/on_create_command
>   39 |     COPY pre-commit/on_create_command /opt/devcontainers/on_create_command
>   40 |     
> --------------------
> ERROR: target pre-commit: failed to solve: failed to compute cache key: failed to calculate checksum of ref 9kqm627fwhvy5m4unfsphplv9::x5e6gpt9ortsusfmomxle1k46: "/on_create_command": not found
> ```
> 
> ## How
> 
> - Try `cwd://common` based on [[docs](https://docs.docker.com/build/bake/remote-definition/#local-named-contexts)](https://docs.docker.com/build/bake/remote-definition/#local-named-contexts)
>     
>     > You can also use the `cwd://` prefix to define local directories in the Bake execution context as named contexts
>     …
>     > 
>     > By contrast, if you omit the `cwd://` prefix, the path would be resolved relative to the build context.
>     > 
> - Alternatively, remove the explicit context, [[per example](https://docs.docker.com/build/bake/remote-definition/)](https://docs.docker.com/build/bake/remote-definition/)
>     
>     > `docker buildx bake "https://github.com/docker/cli.git#v20.10.11" --print`
>     …
>     If the remote Bake definition doesn't specify a build context, the context is automatically set to the Git remote. For example, [[this case](https://github.com/docker/cli/blob/2776a6d694f988c0c1df61cad4bfac0f54e481c8/docker-bake.hcl#L17-L26)](https://github.com/docker/cli/blob/2776a6d694f988c0c1df61cad4bfac0f54e481c8/docker-bake.hcl#L17-L26) uses `https://github.com/docker/cli.git`:
>  