### PR TITLE
Ensure pre commit tool image is not stale

### DIFF
--- a/pre-commit/devcontainer-bake.hcl
+++ b/pre-commit/devcontainer-bake.hcl
@@ -24,7 +24,10 @@ target "pre-commit-tool-image" {
     local_context = BAKE_CMD_CONTEXT
     base_context  = "target:pre-commit-base"
   }
-  output = ["type=registry,name=${PRE_COMMIT_TOOL_IMAGE_NAME}"]
+  output = [
+    "type=registry,name=${PRE_COMMIT_TOOL_IMAGE_NAME}",
+    "type=docker,name=${PRE_COMMIT_TOOL_IMAGE_NAME}"
+  ]
 }
 
 target "pre-commit" {

--- a/pre-commit/on_create_command
+++ b/pre-commit/on_create_command
@@ -2,4 +2,5 @@
 
 set -ex
 
+docker pull "$DEVCONTAINER_PRE_COMMIT_IMAGE"
 pre-commit install


### PR DESCRIPTION
Closes #33 

> ## What
> 
> Ensure pre-commit tool image is up-to-date in cases where an image with the matching name already exists locally
> 
> ## Why
> 
> During changes to the pre-commit tool image specification, contexts may already have an old version of the pre-commit tool image and thus may re-use that older image rather than updating to the latest version
> 
> ## How
> 
> Explicitly pull the image in the caller executable