### PR TITLE
Install autojump in the Zsh layer

### DIFF
--- a/zsh/Dockerfile
+++ b/zsh/Dockerfile
@@ -9,6 +9,10 @@ RUN DEBIAN_FRONTEND=noninteractive \
     apt-get install --allow-unauthenticated --no-install-recommends -y \
       zsh=5* ; \
   fi \
+  && if ! dpkg-query --status autojump ; then \
+    apt-get install --allow-unauthenticated --no-install-recommends -y \
+      autojump=22.5.1* ; \
+  fi \
   && apt-get clean \
   && apt-get autoclean \
   && apt-get autoremove \

--- a/zsh/Dockerfile
+++ b/zsh/Dockerfile
@@ -5,8 +5,10 @@ FROM base_context AS base
 # hadolint ignore=SC2034
 RUN DEBIAN_FRONTEND=noninteractive \
   && apt-get update \
-  && apt-get install --allow-unauthenticated --no-install-recommends -y \
-    zsh=5* \
+  && if ! dpkg-query --status zsh ; then \
+    apt-get install --allow-unauthenticated --no-install-recommends -y \
+      zsh=5* ; \
+  fi \
   && apt-get clean \
   && apt-get autoclean \
   && apt-get autoremove \


### PR DESCRIPTION
Closes #37 

> ## What
> 
> Install the autojump tool in the Zsh layer definition
> 
> ## Why
> 
> Autojump is key to important Zsh features
> 
> ## How
> 
> [Installation instructions](https://github.com/wting/autojump#installation)