### PR TITLE
Install fzf in Zsh layer

### DIFF
--- a/.devcontainer/devcontainer-bake.hcl
+++ b/.devcontainer/devcontainer-bake.hcl
@@ -1,6 +1,8 @@
 variable "devcontainer_layers" {
   default = [
     "docker-client",
+    "zsh-base",
+    "zsh-thefuck-pyenv",
     "zsh",
     "useradd",
     "pre-commit-base",

--- a/.github/workflows/all-layers-image.hcl
+++ b/.github/workflows/all-layers-image.hcl
@@ -3,6 +3,9 @@
 variable "devcontainer_layers" {
   default = [
     "docker-client",
+    "pyenv",
+    "zsh-base",
+    "zsh-thefuck-pyenv",
     "zsh",
     "useradd",
     "pre-commit-base",

--- a/.github/workflows/push-workflow.yaml
+++ b/.github/workflows/push-workflow.yaml
@@ -52,6 +52,7 @@ jobs:
           devcontainer_definition_files_arr=(
             devcontainer-bake.hcl
             docker-client/devcontainer-bake.hcl
+            pyenv/devcontainer-bake.hcl
             zsh/devcontainer-bake.hcl
             useradd/devcontainer-bake.hcl
             pre-commit/devcontainer-bake.hcl

--- a/README.md
+++ b/README.md
@@ -521,8 +521,8 @@ so as to be available during Codespace provisioning.
 
 ### Zsh<a name="zsh"></a>
 
-The Zsh Dockerfile defines steps to install [Zsh](https://zsh.org/) and
-[Oh My Zsh](https://ohmyz.sh/) to the image.
+The Zsh Dockerfile defines steps to install [Zsh](https://zsh.org/), [Oh My Zsh](https://ohmyz.sh/),
+[fzf](https://github.com/junegunn/fzf), and [thefuck](https://github.com/nvbn/thefuck) to the image.
 
 #### Zsh Dockerfile usage<a name="zsh-dockerfile-usage"></a>
 
@@ -537,11 +537,23 @@ target "base" {
   dockerfile = "Dockerfile"
 }
 
+target "zsh-thefuck-pyenv" {
+  dockerfile = "pyenv/Dockerfile"
+  contexts = {
+    base_context = "target:base"
+  }
+  args = {
+    PYTHON_VERSION = "3.8.20"
+    VIRTUALENV_NAME = "thefuck"
+  }
+}
+
 target "default" {
   context = "https://github.com/rcwbr/dockerfile_partials.git#0.7.0"
   dockerfile = "zsh/Dockerfile"
   contexts = {
     base_context = "target:base"
+    pyenv_context = "target:zsh-thefuck-pyenv"
   }
 }
 ```
@@ -551,6 +563,23 @@ target "default" {
 The Zsh partial contains a devcontainer bake config file. See
 [Devcontainer bake files](#devcontainer-bake-files) for general usage. The Zsh bake config file
 accepts no inputs.
+
+The
+[`devcontainer-bake.hcl` config `devcontainer_layers` variable](#devcontainer-bake-files-devcontainer-cache-build-devcontainerdevcontainer-bakehcl-config)
+must list each of the Zsh targets; `zsh-base`, `zsh-thefuck-pyenv`, and `zsh`.
+
+For example:
+
+```hcl
+variable "devcontainer_layers" {
+  default = [
+    "docker-client",
+    "zsh-base",
+    "zsh-thefuck-pyenv",
+    "zsh",
+  ]
+}
+```
 
 ## pre-commit reusable workflow<a name="pre-commit-reusable-workflow"></a>
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ for re-use across multiple applications.
       - [pre-commit Dockerfile usage](#pre-commit-dockerfile-usage)
       - [pre-commit bake file usage](#pre-commit-bake-file-usage)
       - [pre-commit Codespaces usage](#pre-commit-codespaces-usage)
+    - [pyenv](#pyenv)
+      - [pyenv Dockerfile usage](#pyenv-dockerfile-usage)
+      - [pyenv bake file usage](#pyenv-bake-file-usage)
     - [useradd](#useradd)
       - [useradd Dockerfile usage](#useradd-dockerfile-usage)
       - [useradd bake file usage](#useradd-bake-file-usage)
@@ -384,6 +387,46 @@ to `/var/lib/docker/codespacemount/workspace/[repo name]`, e.g.:
   },
 }
 ```
+
+### pyenv<a name="pyenv"></a>
+
+The pyenv layer defines steps to install [pyenv](https://github.com/pyenv/pyenv), leverage it to
+install a specified version of Python, and prepare a virtualenv based on that Python installation.
+
+#### pyenv Dockerfile usage<a name="pyenv-dockerfile-usage"></a>
+
+The recommended usage is via the [Devcontainer bake files](#devcontainer-bake-files). It is also
+possible to use the Dockerfile partial directly.
+
+Use a [Bake](https://docs.docker.com/reference/cli/docker/buildx/bake/) config file, and set the
+`base_context` context as the image to which to apply the pyenv installation. For example:
+
+```hcl
+target "base" {
+  dockerfile = "Dockerfile"
+}
+
+target "default" {
+  context = "https://github.com/rcwbr/dockerfile_partials.git#0.7.0"
+  dockerfile = "pyenv/Dockerfile"
+  contexts = {
+    base_context = "target:base"
+  }
+}
+```
+
+The args accepted by the Dockerfile include:
+
+| Variable          | Required | Default                    | Effect                               |
+| ----------------- | -------- | -------------------------- | ------------------------------------ |
+| `PYTHON_VERSION`  | ✗        | `3.12.4`                   | The version of Python to install     |
+| `VIRTUALENV_NAME` | ✗        | `venv`                     | The name of the virtualenv to create |
+| `PYENV_ROOT`      | ✗        | `/opt/devcontainers/pyenv` | The path in which to install Pyenv   |
+
+#### pyenv bake file usage<a name="pyenv-bake-file-usage"></a>
+
+The pyenv partial contains a devcontainer bake config file. See
+[Devcontainer bake files](#devcontainer-bake-files) for general usage.
 
 ### useradd<a name="useradd"></a>
 

--- a/pyenv/Dockerfile
+++ b/pyenv/Dockerfile
@@ -17,7 +17,9 @@ SHELL [ "/bin/bash", "-o", "pipefail", "-c" ]
   # Instructions: curl -fsSL https://pyenv.run | bash
   # Using locked ref for stability
 RUN \
-  curl -fsSL https://raw.githubusercontent.com/pyenv/pyenv-installer/86a08ac9e38ec3a267e4b5c758891caf1233a2e4/bin/pyenv-installer | bash \
+  if [[ ! -d "$PYENV_ROOT" ]]; then \
+    curl -fsSL https://raw.githubusercontent.com/pyenv/pyenv-installer/86a08ac9e38ec3a267e4b5c758891caf1233a2e4/bin/pyenv-installer | bash ; \
+  fi \
   && "$PYENV_ROOT/bin/pyenv" install "${PYTHON_VERSION}" && "$PYENV_ROOT/bin/pyenv" global "${PYTHON_VERSION}" \
   && pip install --no-cache-dir virtualenv==20.29.2 \
   && virtualenv \

--- a/pyenv/Dockerfile
+++ b/pyenv/Dockerfile
@@ -1,0 +1,39 @@
+ARG VIRTUALENV_NAME=venv
+ARG VIRTUALENV_PATH=/opt/devcontainers/virtualenvs/"$VIRTUALENV_NAME"
+ARG PYENV_ROOT="/opt/devcontainers/pyenv"
+ARG USER=root
+
+
+# Set base_context in the downstream Bake file
+# hadolint ignore=DL3006
+FROM base_context AS pyenv
+ARG PYENV_ROOT
+ARG VIRTUALENV_PATH
+ARG PYTHON_VERSION=3.12.4
+
+# hadolint ignore=DL3002
+USER root
+SHELL [ "/bin/bash", "-o", "pipefail", "-c" ]
+  # Instructions: curl -fsSL https://pyenv.run | bash
+  # Using locked ref for stability
+RUN \
+  curl -fsSL https://raw.githubusercontent.com/pyenv/pyenv-installer/86a08ac9e38ec3a267e4b5c758891caf1233a2e4/bin/pyenv-installer | bash \
+  && "$PYENV_ROOT/bin/pyenv" install "${PYTHON_VERSION}" && "$PYENV_ROOT/bin/pyenv" global "${PYTHON_VERSION}" \
+  && pip install --no-cache-dir virtualenv==20.29.2 \
+  && virtualenv \
+    --python "${PYENV_ROOT}/versions/${PYTHON_VERSION}/bin/python" \
+    --always-copy \
+    "$VIRTUALENV_PATH" \
+  && chmod -R a+r "${PYENV_ROOT}" \
+  && chmod -R a+x "${PYENV_ROOT}/bin" \
+  && chmod -R a+r "${VIRTUALENV_PATH}" \
+  && chmod -R a+x "${VIRTUALENV_PATH}/bin"
+
+
+# hadolint ignore=DL3006
+FROM base_context AS virtualenv
+ARG PYENV_ROOT
+ARG VIRTUALENV_PATH
+ENV PATH="${VIRTUALENV_PATH}:$PATH"
+COPY --from=pyenv ${PYENV_ROOT} ${PYENV_ROOT}
+COPY --from=pyenv ${VIRTUALENV_PATH} ${VIRTUALENV_PATH}

--- a/pyenv/devcontainer-bake.hcl
+++ b/pyenv/devcontainer-bake.hcl
@@ -1,0 +1,3 @@
+target "pyenv" {
+  dockerfile = "pyenv/Dockerfile"
+}

--- a/zsh/Dockerfile
+++ b/zsh/Dockerfile
@@ -1,3 +1,6 @@
+# hadolint ignore=DL3006
+FROM pyenv_context AS pyenv
+
 # Set base_context in the downstream Bake file
 # hadolint ignore=DL3006
 FROM base_context AS base
@@ -23,6 +26,16 @@ RUN DEBIAN_FRONTEND=noninteractive \
   && rm -rf /var/cache/debconf \
   && rm -rf /var/lib/apt/lists/*
 
+ARG THEFUCK_VENV=/opt/devcontainers/virtualenvs/thefuck
+ENV THEFUCK_VENV=${THEFUCK_VENV}
+COPY --from=pyenv /opt/devcontainers/pyenv /opt/devcontainers/pyenv
+COPY --from=pyenv ${THEFUCK_VENV} ${THEFUCK_VENV}
+SHELL [ "/bin/bash", "-c" ]
+# hadolint ignore=SC1091
+RUN \
+  source "${THEFUCK_VENV}/bin/activate" \
+  && pip install --no-cache-dir thefuck==3.32 \
+  && echo "PATH=\"${THEFUCK_VENV}/bin:\$PATH\" \"${THEFUCK_VENV}/bin/thefuck\" \"\$@\"" > /usr/local/bin/thefuck && chmod a+x /usr/local/bin/thefuck
 
 # Include Oh My Zsh initialization in config for devcontainers onCreateCommand
 COPY common/on_create_command /opt/devcontainers/on_create_command

--- a/zsh/Dockerfile
+++ b/zsh/Dockerfile
@@ -13,6 +13,10 @@ RUN DEBIAN_FRONTEND=noninteractive \
     apt-get install --allow-unauthenticated --no-install-recommends -y \
       autojump=22.5.1* ; \
   fi \
+  && if ! dpkg-query --status fzf ; then \
+    apt-get install --allow-unauthenticated --no-install-recommends -y \
+      fzf=0.38.0* ; \
+  fi \
   && apt-get clean \
   && apt-get autoclean \
   && apt-get autoremove \

--- a/zsh/devcontainer-bake.hcl
+++ b/zsh/devcontainer-bake.hcl
@@ -1,3 +1,22 @@
+target "zsh-base" {
+  dockerfile-inline = "FROM base_context"
+}
+
+target "zsh-thefuck-pyenv" {
+  dockerfile = "pyenv/Dockerfile"
+  contexts = {
+    base_context = "target:zsh-base"
+  }
+  args = {
+    PYTHON_VERSION  = "3.8.20"
+    VIRTUALENV_NAME = "thefuck"
+  }
+}
+
 target "zsh" {
   dockerfile = "zsh/Dockerfile"
+  contexts = {
+    base_context  = "target:zsh-base"
+    pyenv_context = "target:zsh-thefuck-pyenv"
+  }
 }


### PR DESCRIPTION
Closes #39 

> ## What
> 
> Install the fzf tool in the Zsh layer definition
> 
> ## Why
> 
> Fzf is key to important Zsh features
> 
> ## How
> 
> [Installation instructions](https://github.com/junegunn/fzf?tab=readme-ov-file#installation)